### PR TITLE
Maxpool

### DIFF
--- a/convolutions/run.py
+++ b/convolutions/run.py
@@ -20,9 +20,13 @@ from run_conv_net import *
 train_dataset, train_labels = reformat_as_cube(train_dataset, train_labels)
 valid_dataset, valid_labels = reformat_as_cube(valid_dataset, valid_labels)
 test_dataset, test_labels = reformat_as_cube(test_dataset, test_labels)
+
 print('Cube Reformatted Training set', train_dataset.shape, train_labels.shape)
+# Cube Reformatted Training set (200000, 28, 28, 1) (200000, 10)
 print('Cube Reformatted Validation set', valid_dataset.shape, valid_labels.shape)
+# Cube Reformatted Validation set (10000, 28, 28, 1) (10000, 10)
 print('Cube Reformatted Test set', test_dataset.shape, test_labels.shape)
+# Cube Reformatted Test set (10000, 28, 28, 1) (10000, 10)
 
 graph = tf.Graph()
 

--- a/convolutions/run_conv_net.py
+++ b/convolutions/run_conv_net.py
@@ -7,7 +7,7 @@ sys.path.append('/Users/keithjohnson/courses/deep_learning')
 from accuracy import accuracy
 
 batch_size = 16
-patch_size = 5
+patch_size = 5 #k subj ≡ kernel size along axis j.
 depth = 16
 num_hidden = 64
 

--- a/convolutions/run_conv_net.py
+++ b/convolutions/run_conv_net.py
@@ -47,10 +47,12 @@ def run_conv_net(
           def model(data):
             conv = tf.nn.conv2d(data, layer1_weights, strides=[1, 1, 1, 1], padding='SAME')
             hidden = tf.nn.relu(conv + layer1_biases)
-            conv = tf.nn.conv2d(hidden, layer2_weights, [1, 2, 2, 1], padding='SAME')
+            pool =  tf.nn.max_pool(hidden, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
+            conv = tf.nn.conv2d(pool, layer2_weights, strides=[1, 1, 1, 1], padding='SAME')
             hidden = tf.nn.relu(conv + layer2_biases)
-            shape = hidden.get_shape().as_list()
-            reshape = tf.reshape(hidden, [shape[0], shape[1] * shape[2] * shape[3]])
+            pool =  tf.nn.max_pool(hidden, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
+            shape = pool.get_shape().as_list()
+            reshape = tf.reshape(pool, [shape[0], shape[1] * shape[2] * shape[3]])
             hidden = tf.nn.relu(tf.matmul(reshape, layer3_weights) + layer3_biases)
             return tf.matmul(hidden, layer4_weights) + layer4_biases
 

--- a/convolutions/run_conv_net.py
+++ b/convolutions/run_conv_net.py
@@ -45,7 +45,7 @@ def run_conv_net(
 
           # Model.
           def model(data):
-            conv = tf.nn.conv2d(data, layer1_weights, [1, 2, 2, 1], padding='SAME')
+            conv = tf.nn.conv2d(data, layer1_weights, strides=[1, 1, 1, 1], padding='SAME')
             hidden = tf.nn.relu(conv + layer1_biases)
             conv = tf.nn.conv2d(hidden, layer2_weights, [1, 2, 2, 1], padding='SAME')
             hidden = tf.nn.relu(conv + layer2_biases)


### PR DESCRIPTION
Problem 1
The convolutional model above uses convolutions with stride 2 to reduce the dimensionality. Replace the strides by a max pooling operation (nn.max_pool()) of stride 2 and kernel size 2.


The following was helpful from [these tf docs](https://www.tensorflow.org/versions/r0.10/tutorials/mnist/pros/index.html):

> Convolution and Pooling

> TensorFlow also gives us a lot of flexibility in convolution and pooling operations. How do we handle the boundaries? What is our stride size? In this example, we're always going to choose the vanilla version. Our convolutions uses a stride of one and are zero padded so that the output is the same size as the input. Our pooling is plain old max pooling over 2x2 blocks. To keep our code cleaner, let's also abstract those operations into functions.

```
def conv2d(x, W):
  return tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding='SAME')

def max_pool_2x2(x):
  return tf.nn.max_pool(x, ksize=[1, 2, 2, 1],
                        strides=[1, 2, 2, 1], padding='SAME')
```